### PR TITLE
#22 PIN-83 Fixed: internal ID type check counts with null value

### DIFF
--- a/src/ProjectBundle/Entity/Project.php
+++ b/src/ProjectBundle/Entity/Project.php
@@ -204,7 +204,7 @@ class Project implements ExportableInterface
     /**
      * @return string
      */
-    public function getInternalId(): string
+    public function getInternalId(): ?string
     {
         return $this->internalId;
     }

--- a/src/ProjectBundle/Entity/Project.php
+++ b/src/ProjectBundle/Entity/Project.php
@@ -202,7 +202,7 @@ class Project implements ExportableInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getInternalId(): ?string
     {
@@ -210,7 +210,7 @@ class Project implements ExportableInterface
     }
 
     /**
-     * @param string $internalId
+     * @param string|null $internalId
      */
     public function setInternalId($internalId)
     {


### PR DESCRIPTION
@blazekv reported error with type check:
>  {"error":{"code":500,"message":"Internal Server Error","exception":[{"message":"Type error: Return value of ProjectBundle\Entity\Project::getInternalId() must be of the type string, null returned","class":"Symfony\Component\Debug\Exception\FatalThrowableError","trace":