### PR TITLE
Quick workaround to make beneficiary tests work repeatly

### DIFF
--- a/tests/DistributionBundle/Controller/DistributionControllerTest.php
+++ b/tests/DistributionBundle/Controller/DistributionControllerTest.php
@@ -47,7 +47,7 @@ class DistributionControllerTest extends BMSServiceTestCase
      */
     public function testCreateDistribution()
     {
-        $this->removeHousehold($this->namefullnameHousehold);
+//        $this->removeHousehold($this->namefullnameHousehold);
         $this->createHousehold();
 
         $criteria = array(


### PR DESCRIPTION
Run tests repeatly makes mistakes in beneficiary test due to invalid remove household.