### PR TITLE
PIN-352: Fixed invalid query in filtering by criteria.

### DIFF
--- a/src/BeneficiaryBundle/Repository/BeneficiaryRepository.php
+++ b/src/BeneficiaryBundle/Repository/BeneficiaryRepository.php
@@ -291,7 +291,7 @@ class BeneficiaryRepository extends AbstractCriteriaRepository
             $andStatement->add('cs'.$i . '.fieldString = :csName'.$i);
             $andStatement->add('csa'.$i . '.answer ' . $condition . ' :parameter'.$i);
             $orStatement->add($andStatement);
-            $qb->addSelect('cs'.$i . '.fieldString AS ' . $field.$i);
+            $qb->addSelect('cs'.$i . '.fieldString');
         }
 
         // The selection criteria is directly a field in the Household table


### PR DESCRIPTION
There was invalid and useless alias created from field_string and iteration number. For example, "Custom locality1". Space in field_string caused errors.